### PR TITLE
delete _gid tracking cookie

### DIFF
--- a/src/cookies-eu-banner.js
+++ b/src/cookies-eu-banner.js
@@ -23,7 +23,7 @@
     this.cookieTimeout = 33696000000; // 13 months in milliseconds
     this.bots = /bot|googlebot|crawler|spider|robot|crawling/i;
     this.cookieName = 'hasConsent';
-    this.trackingCookiesNames = [ '__utma', '__utmb', '__utmc', '__utmt', '__utmv', '__utmz', '_ga', '_gat' ];
+    this.trackingCookiesNames = [ '__utma', '__utmb', '__utmc', '__utmt', '__utmv', '__utmz', '_ga', '_gat', '_gid' ];
     this.launchFunction = launchFunction;
     this.waitAccept = waitAccept || false;
     this.init();


### PR DESCRIPTION
When using the `analytics.js` variant, a `_gid` cookie is set too:

<img width="189" alt="screen shot 2018-05-15 at 13 43 36" src="https://user-images.githubusercontent.com/90316/40054747-3894cf08-5846-11e8-8c05-2c6fb8af152b.png">

This PR adds this one to the array of cookie names to be deleted when user hits _Reject_.