### PR TITLE
Provide some null safety for #removeBanner

### DIFF
--- a/src/cookies-eu-banner.js
+++ b/src/cookies-eu-banner.js
@@ -62,7 +62,7 @@
         rejectButton = document.getElementById('cookies-eu-reject'),
         acceptButton = document.getElementById('cookies-eu-accept'),
         moreLink = document.getElementById('cookies-eu-more'),
-        waitRemove = (banner.dataset.waitRemove === undefined) ? 0 : parseInt(banner.dataset.waitRemove); 
+        waitRemove = (banner.dataset.waitRemove === undefined) ? 0 : parseInt(banner.dataset.waitRemove);
 
       banner.style.display = 'block';
 
@@ -165,7 +165,9 @@
      */
     removeBanner: function (banner, wait) {
       setTimeout (function() {
-        banner.parentNode.removeChild(banner);
+        if (banner && banner.parentNode) {
+          banner.parentNode.removeChild(banner);
+        }
       }, wait);
     }
   };


### PR DESCRIPTION
In our production environment occasionally the following error occurred: `e.parentNode is null` at the following position:

```
cookies-eu-banner.js:178:0:in `banner'

176     removeBanner: function (banner, wait) {
177       setTimeout (function() {
178         banner.parentNode.removeChild(banner);
179       }, wait);
180     }
```

We figured it might be the work of some add blocker or something similar, but were not able to hunt it down.

So let's get rid of the error - the banner won't need any removal if its not there in the first place, right?

Thanks and best,
Jo