### PR TITLE
feat: Add 'before-remove' class in removeBanner

### DIFF
--- a/src/cookies-eu-banner.js
+++ b/src/cookies-eu-banner.js
@@ -169,8 +169,9 @@
      * to specify their own transition effects
      */
     removeBanner: function (wait) {
+      var banner = document.getElementById('cookies-eu-banner');
+      banner.classList.add('before-remove');
       setTimeout (function() {
-        var banner = document.getElementById('cookies-eu-banner');
         if (banner && banner.parentNode) {
           banner.parentNode.removeChild(banner);
         }

--- a/src/cookies-eu-banner.js
+++ b/src/cookies-eu-banner.js
@@ -170,7 +170,7 @@
      */
     removeBanner: function (wait) {
       var banner = document.getElementById('cookies-eu-banner');
-      banner.classList.add('before-remove');
+      banner.classList.add('cookies-eu-banner--before-remove');
       setTimeout (function() {
         if (banner && banner.parentNode) {
           banner.parentNode.removeChild(banner);


### PR DESCRIPTION
Allows developer to create hiding-animation before the banner is removed. 
Fixes #53