### PR TITLE
Fix the launchFunction argument when not a function

### DIFF
--- a/src/cookies-eu-banner.js
+++ b/src/cookies-eu-banner.js
@@ -24,7 +24,7 @@
     this.bots = /bot|crawler|spider|crawling/i;
     this.cookieName = 'hasConsent';
     this.trackingCookiesNames = ['__utma', '__utmb', '__utmc', '__utmt', '__utmv', '__utmz', '_ga', '_gat', '_gid'];
-    this.launchFunction = launchFunction;
+    this.launchFunction = 'function' === typeof launchFunction ? launchFunction : function () {};
     this.waitAccept = waitAccept || false;
     this.useLocalStorage = useLocalStorage || false;
     this.init();


### PR DESCRIPTION
When constructing the `CookiesEuBanner` instance, it is possible that the argument passed as the `launchFunction` named parameter may not be a function.

```js
// Boolean explicitly passed here
new CookiesEuBanner(false);

// Undefined implicitly passed here:
new CookiesEuBanner();
```

For any of the above scenarios, the code will throw a `TypeError` indicating that the designated `launchFunction` is not a function.

Hence, a type check is required to ascertain that the `launchFunction` is a function. And if not, a no-op function can be used as a fallback.